### PR TITLE
Set 'https://api.treasuredata.com' instead of using secret variables

### DIFF
--- a/CustomScripts/codes/access_summary/access_summary.dig
+++ b/CustomScripts/codes/access_summary/access_summary.dig
@@ -10,4 +10,4 @@ _export:
         image: "digdag/digdag-python:3.7"
     _env:
         TD_API_KEY: ${secret:td.apikey}
-        TD_API_SERVER: ${secret:td.apiserver}
+        TD_API_SERVER: "https://api.treasuredata.com"

--- a/CustomScripts/codes/access_summary/access_summary_pandas.dig
+++ b/CustomScripts/codes/access_summary/access_summary_pandas.dig
@@ -10,4 +10,4 @@ _export:
         image: "digdag/digdag-python:3.7"
     _env:
         TD_API_KEY: ${secret:td.apikey}
-        TD_API_SERVER: ${secret:td.apiserver}
+        TD_API_SERVER: "https://api.treasuredata.com"

--- a/CustomScripts/codes/access_summary/py_scripts/examples.py
+++ b/CustomScripts/codes/access_summary/py_scripts/examples.py
@@ -42,7 +42,7 @@ def summarize_access_pandas(database_name, table_name):
     
     res = client.query(f"select code, method from  sample_datasets.www_access")
     df = pd.DataFrame(**res)
-    df2 = df.groupby(["code", "method"]).size.to_frame("size").reset_index()
+    df2 = df.groupby(["code", "method"]).size().to_frame("size").reset_index()
 
     client.load_table_from_dataframe(
         df2,

--- a/CustomScripts/codes/exercise/ex1/rss_import.dig
+++ b/CustomScripts/codes/exercise/ex1/rss_import.dig
@@ -17,4 +17,4 @@ _export:
     - "https://feeds.dailyfeed.jp/feed/s/7/887.rss"
   _env:
     TD_API_KEY: ${secret:td.apikey}
-    TD_API_SERVER: ${secret:td.apiserver}
+    TD_API_SERVER: "https://api.treasuredata.com"

--- a/CustomScripts/codes/exercise/ex2/ingest.dig
+++ b/CustomScripts/codes/exercise/ex2/ingest.dig
@@ -9,4 +9,4 @@ _export:
     image: "digdag/digdag-python:3.7"
   _env:
     TD_API_KEY: ${secret:td.apikey}
-    TD_API_SERVER: ${secret:td.apiserver}
+    TD_API_SERVER: "https://api.treasuredata.com"

--- a/CustomScripts/codes/exercise/ex2/predict_sales.dig
+++ b/CustomScripts/codes/exercise/ex2/predict_sales.dig
@@ -13,4 +13,4 @@ _export:
     image: 'digdag/digdag-python:3.7'
   _env:
     TD_API_KEY: ${secret:td.apikey}
-    TD_API_SERVER: ${secret:td.apiserver}
+    TD_API_SERVER: "https://api.treasuredata.com"

--- a/CustomScripts/codes/exercise/ex2/predict_sales_with_graph.dig
+++ b/CustomScripts/codes/exercise/ex2/predict_sales_with_graph.dig
@@ -13,7 +13,7 @@ _export:
     image: 'digdag/digdag-python:3.7'
   _env:
     TD_API_KEY: ${secret:td.apikey}
-    TD_API_SERVER: ${secret:td.apiserver}
+    TD_API_SERVER: "https://api.treasuredata.com"
     AWS_ACCESS_KEY_ID: ${secret:s3.access_key_id}
     AWS_SECRET_ACCESS_KEY: ${secret:s3.secret_access_key}
     S3_BUCKET: ${secret:s3.bucket}

--- a/CustomScripts/codes/pandas/pandas-df.dig
+++ b/CustomScripts/codes/pandas/pandas-df.dig
@@ -10,7 +10,7 @@ _export:
     image: "digdag/digdag-python:3.7"
   _env:
     TD_API_KEY: ${secret:td.apikey}
-    TD_API_SERVER: ${secret:td.apiserver}
+    TD_API_SERVER: "https://api.treasuredata.com"
 
 +write_into_td:
   py>: py_scripts.examples.write_td_table
@@ -20,4 +20,4 @@ _export:
     image: "digdag/digdag-python:3.7"
   _env:
     TD_API_KEY: ${secret:td.apikey}
-    TD_API_SERVER: ${secret:td.apiserver}
+    TD_API_SERVER: "https://api.treasuredata.com"


### PR DESCRIPTION
Set 'https://api.treasuredata.com' instead of using secret variables as below.
`TD_API_SERVER: "https://api.treasuredata.com"`

In addition, fixed a bug [here](https://github.com/treasure-data/treasure-academy-cdp/compare/remove_secret_endponit?expand=1#diff-b2e10af844ed90f7f7c1d5f112b20716732192ed2d7ee74c20b6cfa91a5a3710R45).